### PR TITLE
Upgrade to aws-sdk v2

### DIFF
--- a/lib/rp/emr/step/pig.rb
+++ b/lib/rp/emr/step/pig.rb
@@ -28,7 +28,7 @@ module RP
 
         def upload_script!
           # puts "Uploading to s3://#{script_bucket}/#{script_key}"
-          s3.buckets[script_bucket].objects[script_key].write(script)
+          s3.bucket(script_bucket).object(script_key).put(body: script)
         end
 
         def script
@@ -76,7 +76,7 @@ module RP
         end
 
         def s3
-          AWS::S3.new
+          Aws::S3::Resource.new
         end
       end
     end

--- a/rp-emr.gemspec
+++ b/rp-emr.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"
-  spec.add_dependency "aws-sdk"
+  spec.add_dependency "aws-sdk", "~> 2.0"
   spec.add_dependency "assembler"
   spec.add_dependency "thor"
 

--- a/spec/rp/emr/step/pig_spec.rb
+++ b/spec/rp/emr/step/pig_spec.rb
@@ -5,8 +5,8 @@ describe RP::EMR::Step::Pig do
     let(:written) { [] }
 
     before(:each) do
-      allow_any_instance_of(AWS::S3::S3Object).to receive(:write) do |data|
-        written << data
+      allow_any_instance_of(Aws::S3::Object).to receive(:put) do |data, args|
+        written << args[:body]
       end
     end
 
@@ -39,13 +39,12 @@ describe RP::EMR::Step::Pig do
     end
 
     it "writes script to expected path" do
-      expect_any_instance_of(AWS::S3::ObjectCollection).to receive(:[]).with(expected_script_path).and_call_original
+      expect_any_instance_of(Aws::S3::Bucket).to receive(:object).with(expected_script_path).and_call_original
 
       step.to_hash
     end
 
     it "uploads pig script contents" do
-      pending "Strange behavior with test setup?"
       step.to_hash
 
       expect(written).to eq(['script_contents'])


### PR DESCRIPTION
Looking into modernizing the stack we're using for the EMR job to see if that helps make it more reliable.

To kick off jobs with the latest EMR AMIs we need to be using v2 of aws-sdk. (The version specifier changed from `ami_version` to `release_label` and v1 doesn't support `release_label`)